### PR TITLE
multiple definition of _Uarm_get_elf_image and dl_iterate_phdr

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,6 @@
+This code is forked from https://github.com/jrmuizel/libunwind.git
+
+
 -*- mode: Outline -*-
 
 This is version 1.0 of the unwind library.  This library supports

--- a/README.android
+++ b/README.android
@@ -1,1 +1,4 @@
-./configure CC=arm-eabi-gcc CPPFLAGS="-I/home/jrmuizel/android-ndk-r5c/platforms/android-5/arch-arm/usr/include/" CFLAGS="-march=armv7-a -mthumb -mfpu=vfp -mfloat-abi=softfp -nostdlib" LDFLAGS="-Wl,-rpath-link=/home/jrmuizel/android-ndk-r5c/platforms/android-5/arch-arm/usr/lib/ -L/home/jrmuizel/android-ndk-r5c/platforms/android-5/arch-arm/usr/lib/" LIBS="-lc -lgcc" -host=arm-eabi 
+
+export NDK_SROOT=....../android-ndk-r9d/platforms/android-18/arch-arm/
+
+./configure CC=arm-linux-androideabi-gcc CPPFLAGS="--sysroot=${NDK_SROOT}" CFLAGS="-march=armv7-a -mthumb -mfpu=vfp -mfloat-abi=softfp -nostdlib --sysroot=${NDK_SROOT}" LDFLAGS="--sysroot=${NDK_SROOT}" -host=arm-linux-androideabi --prefix=/tmp/libunwind_inst LIBS="-lc -lgcc"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,14 +147,14 @@ libunwind_la_SOURCES_arm = $(libunwind_la_SOURCES_arm_common)		    \
 	arm/Lcreate_addr_space.c arm/Lget_proc_info.c arm/Lget_save_loc.c   \
 	arm/Lglobal.c arm/Linit.c arm/Linit_local.c arm/Linit_remote.c	    \
 	arm/Lis_signal_frame.c arm/Lregs.c arm/Lresume.c arm/Lstep.c	    \
-	arm/Lex_tables.c os-linux.c dl-iterate-phdr.c
+	arm/Lex_tables.c
 
 libunwind_arm_la_SOURCES_arm = $(libunwind_la_SOURCES_arm_common)	    \
 	$(libunwind_la_SOURCES_generic)					    \
 	arm/Gcreate_addr_space.c arm/Gget_proc_info.c arm/Gget_save_loc.c   \
 	arm/Gglobal.c arm/Ginit.c arm/Ginit_local.c arm/Ginit_remote.c	    \
 	arm/Gis_signal_frame.c arm/Gregs.c arm/Gresume.c arm/Gstep.c	    \
-	arm/Gex_tables.c os-linux.c dl-iterate-phdr.c
+	arm/Gex_tables.c
 
 # The list of files that go both into libunwind and libunwind-ia64:
 noinst_HEADERS += ia64/init.h ia64/offsets.h ia64/regs.h		    \


### PR DESCRIPTION
Appears that os-linux.o and dl-iterate-phdr.o are added twice. Therefore the linker finds a multiple definition of "_Uarm_get_elf_image" and "dl_iterate_phdr".

Thanks,
Xavi
